### PR TITLE
Build script bug and updating dependency constraints.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -3,7 +3,7 @@ import Data.Version ( showVersion )
 import Distribution.Package ( PackageName(PackageName), Package, PackageId, InstalledPackageId, packageVersion, packageName )
 import Distribution.PackageDescription ( PackageDescription(), TestSuite(..) )
 import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
-import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose, copyFiles )
+import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose )
 import Distribution.Simple.BuildPaths ( autogenModulesDir )
 import Distribution.Simple.Setup ( BuildFlags(buildVerbosity), Flag(..), fromFlag, HaddockFlags(haddockDistPref))
 import Distribution.Simple.LocalBuildInfo ( withLibLBI, withTestLBI, LocalBuildInfo(), ComponentLocalBuildInfo(componentPackageDeps) )
@@ -17,7 +17,6 @@ main = defaultMainWithHooks simpleUserHooks
      generateBuildModule (fromFlag (buildVerbosity flags)) pkg lbi
      buildHook simpleUserHooks pkg lbi hooks flags
   , postHaddock = \args flags pkg lbi -> do
-     copyFiles normal (haddockOutputDir flags pkg) [("images","Hierarchy.png")]
      postHaddock simpleUserHooks args flags pkg lbi
   }
 

--- a/bit-array.cabal
+++ b/bit-array.cabal
@@ -51,7 +51,7 @@ library
     loch-th == 0.2.*,
     placeholders == 0.1.*,
     -- general:
-    numeric-qq >= 0.1.2 && < 0.2,
+    numeric-qq >= 0.1.3 && < 0.2,
     base >= 4.5 && < 5
   default-extensions:
     Arrows, BangPatterns, ConstraintKinds, DataKinds, DefaultSignatures, DeriveDataTypeable, DeriveFunctor, DeriveGeneric, EmptyDataDecls, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, ImpredicativeTypes, LambdaCase, LiberalTypeSynonyms, MagicHash, MultiParamTypeClasses, MultiWayIf, NoImplicitPrelude, NoMonomorphismRestriction, OverloadedStrings, PatternGuards, ParallelListComp, QuasiQuotes, RankNTypes, RecordWildCards, ScopedTypeVariables, StandaloneDeriving, TemplateHaskell, TupleSections, TypeFamilies, TypeOperators, UnboxedTuples
@@ -69,10 +69,10 @@ test-suite doctests
   ghc-options:
     -threaded
   build-depends:
-    doctest == 0.9.*,
+    doctest >= 0.9 && < 0.11,
     directory == 1.2.*,
-    filepath == 1.3.*,
-    base
+    filepath >= 1.3 && < 1.5,
+    base >= 4.5 && < 5
   default-extensions:
     Arrows, BangPatterns, ConstraintKinds, DataKinds, DefaultSignatures, DeriveDataTypeable, DeriveFunctor, DeriveGeneric, EmptyDataDecls, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, ImpredicativeTypes, LambdaCase, LiberalTypeSynonyms, MultiParamTypeClasses, MultiWayIf, NoImplicitPrelude, NoMonomorphismRestriction, OverloadedStrings, PatternGuards, ParallelListComp, QuasiQuotes, RankNTypes, RecordWildCards, ScopedTypeVariables, StandaloneDeriving, TemplateHaskell, TupleSections, TypeFamilies, TypeOperators
   default-language:


### PR DESCRIPTION
~~\* Update project to be compatible with stack using LTS snapshot 3.18.~~
~~\* Add gitignore file that is aware of both stack- and cabal-based binaries/intermediate files.~~
- Fixed issue with non-existent Hierarchy.png image trying to be copied in the build script.
- Relaxed doctest and filepath dependency constraints.
- Bumped min version of numeric-qq to 0.1.3.
- Set range of acceptable versions of base.
