### PR TITLE
Use FiniteBits instead of Bits so library does not rely on partial function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,46 @@
-language: haskell
+# For details on this setup see https://github.com/hvr/multi-ghc-travis
 
-ghc:
-  - 7.6
-  - 7.8
+env:
+  - GHCVER=7.6.3
+  - GHCVER=7.8.2
+  - GHCVER=7.10.2
 
+matrix:
+  allow_failures:
+    - env: GHCVER=head
+
+before_install:
+  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install cabal-install-1.20 ghc-$GHCVER
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/1.20/bin:$PATH
+  # Alex & Happy
+  - |
+    if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "7.8" ] || [ ${GHCVER%.*} = "7.10" ]; then
+      travis_retry sudo apt-get install happy-1.19.3 alex-3.1.3
+      export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.3/bin:$PATH
+    else
+      travis_retry sudo apt-get install happy alex
+    fi
 install:
-  - cabal install happy # a "haskell-src-exts" implicit dependency workaround
+  - cabal update
   - cabal install --only-dependencies --enable-tests --enable-benchmarks
 
+# Here starts the actual work to be performed for the package under test; 
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+  # "-v2" provides useful information for debugging
+  - cabal configure --enable-tests --enable-benchmarks -v2
+  - cabal build
+  - cabal test --show-details=never
+  - cabal sdist
+  # The following scriptlet checks that the resulting source distribution can be built & installed
+  - |
+    export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
+    cd dist/;
+    if [ -f "$SRC_TGZ" ]; then
+       cabal install "$SRC_TGZ";
+    else
+       echo "expected '$SRC_TGZ' not found";
+       exit 1;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # For details on this setup see https://github.com/hvr/multi-ghc-travis
 
 env:
-  - GHCVER=7.6.3
   - GHCVER=7.8.2
   - GHCVER=7.10.2
 

--- a/Setup.hs
+++ b/Setup.hs
@@ -3,7 +3,7 @@ import Data.Version ( showVersion )
 import Distribution.Package ( PackageName(PackageName), Package, PackageId, InstalledPackageId, packageVersion, packageName )
 import Distribution.PackageDescription ( PackageDescription(), TestSuite(..) )
 import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
-import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose, copyFiles )
+import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose )
 import Distribution.Simple.BuildPaths ( autogenModulesDir )
 import Distribution.Simple.Setup ( BuildFlags(buildVerbosity), Flag(..), fromFlag, HaddockFlags(haddockDistPref))
 import Distribution.Simple.LocalBuildInfo ( withLibLBI, withTestLBI, LocalBuildInfo(), ComponentLocalBuildInfo(componentPackageDeps) )
@@ -17,7 +17,6 @@ main = defaultMainWithHooks simpleUserHooks
      generateBuildModule (fromFlag (buildVerbosity flags)) pkg lbi
      buildHook simpleUserHooks pkg lbi hooks flags
   , postHaddock = \args flags pkg lbi -> do
-     copyFiles normal (haddockOutputDir flags pkg) [("images","Hierarchy.png")]
      postHaddock simpleUserHooks args flags pkg lbi
   }
 

--- a/bit-array.cabal
+++ b/bit-array.cabal
@@ -51,7 +51,7 @@ library
     loch-th == 0.2.*,
     placeholders == 0.1.*,
     -- general:
-    numeric-qq >= 0.1.2 && < 0.2,
+    numeric-qq >= 0.1.3 && < 0.2,
     base >= 4.5 && < 5
   default-extensions:
     Arrows, BangPatterns, ConstraintKinds, DataKinds, DefaultSignatures, DeriveDataTypeable, DeriveFunctor, DeriveGeneric, EmptyDataDecls, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, ImpredicativeTypes, LambdaCase, LiberalTypeSynonyms, MagicHash, MultiParamTypeClasses, MultiWayIf, NoImplicitPrelude, NoMonomorphismRestriction, OverloadedStrings, PatternGuards, ParallelListComp, QuasiQuotes, RankNTypes, RecordWildCards, ScopedTypeVariables, StandaloneDeriving, TemplateHaskell, TupleSections, TypeFamilies, TypeOperators, UnboxedTuples
@@ -69,10 +69,10 @@ test-suite doctests
   ghc-options:
     -threaded
   build-depends:
-    doctest == 0.9.*,
+    doctest >= 0.9 && < 0.11,
     directory == 1.2.*,
-    filepath == 1.3.*,
-    base
+    filepath >= 1.3 && < 1.5,
+    base >= 4.5 && < 5
   default-extensions:
     Arrows, BangPatterns, ConstraintKinds, DataKinds, DefaultSignatures, DeriveDataTypeable, DeriveFunctor, DeriveGeneric, EmptyDataDecls, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, ImpredicativeTypes, LambdaCase, LiberalTypeSynonyms, MultiParamTypeClasses, MultiWayIf, NoImplicitPrelude, NoMonomorphismRestriction, OverloadedStrings, PatternGuards, ParallelListComp, QuasiQuotes, RankNTypes, RecordWildCards, ScopedTypeVariables, StandaloneDeriving, TemplateHaskell, TupleSections, TypeFamilies, TypeOperators
   default-language:

--- a/bit-array.cabal
+++ b/bit-array.cabal
@@ -52,7 +52,7 @@ library
     placeholders == 0.1.*,
     -- general:
     numeric-qq >= 0.1.3 && < 0.2,
-    base >= 4.5 && < 5
+    base >= 4.7 && < 5
   default-extensions:
     Arrows, BangPatterns, ConstraintKinds, DataKinds, DefaultSignatures, DeriveDataTypeable, DeriveFunctor, DeriveGeneric, EmptyDataDecls, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, ImpredicativeTypes, LambdaCase, LiberalTypeSynonyms, MagicHash, MultiParamTypeClasses, MultiWayIf, NoImplicitPrelude, NoMonomorphismRestriction, OverloadedStrings, PatternGuards, ParallelListComp, QuasiQuotes, RankNTypes, RecordWildCards, ScopedTypeVariables, StandaloneDeriving, TemplateHaskell, TupleSections, TypeFamilies, TypeOperators, UnboxedTuples
   default-language:

--- a/library/BitArray.hs
+++ b/library/BitArray.hs
@@ -8,75 +8,71 @@ import qualified NumericQQ
 
 
 -- |
--- A @newtype@ wrapper which provides an array-like interface to a type, 
--- which has instances of 'Bits' and 'Num'.
--- 
+-- A @newtype@ wrapper which provides an array-like interface to a type,
+-- which has instances of 'Bits', 'FiniteBits' and 'Num'.
+--
 -- You can construct bit arrays by wrapping numeric values:
--- 
+--
 -- >>> BitArray (7 :: Int8)
 -- [qq|00000111|]
--- 
+--
 -- or directly from numeric literals:
--- 
+--
 -- >>> 7 :: BitArray Int8
 -- [qq|00000111|]
--- 
--- or using a binary notation quasi-quoter, 
+--
+-- or using a binary notation quasi-quoter,
 -- assuming you have the @QuasiQuotes@ pragma turned on:
--- 
+--
 -- >>> [qq|0111|] :: BitArray Int8
 -- [qq|00000111|]
--- 
--- @BitArray@ derives the 'Bits' instance from the base type,
--- so it supports all the standard bitwise operations as well.
--- 
--- Note that this library does not support the 'Integer' type,
--- since 'Integer' has no implementation of the 'bitSize' function,
--- which this library heavily relies on.
--- You will get a runtime exception if you use it with 'Integer'.
+--
+-- @BitArray@ derives the 'Bits' and 'FiniteBits' instances from the base type,
+-- so it supports all the standard bitwise operations for fixed-size integral
+-- types.
 newtype BitArray a = BitArray a
-  deriving (Bounded, Enum, Eq, Integral, Data, Num, Ord, Real, Ix, Generic, 
-            Typeable, Bits)
+  deriving (Bounded, Enum, Eq, Integral, Data, Num, Ord, Real, Ix, Generic,
+            Typeable, Bits, FiniteBits)
 
--- | 
+-- |
 -- Produces a literal of zeros and ones.
--- 
+--
 -- >>> show (BitArray (5 :: Int8))
 -- "[qq|00000101|]"
-instance (Bits a) => Show (BitArray a) where
+instance (FiniteBits a) => Show (BitArray a) where
   show = wrap . toString
     where
       wrap = ("[qq|" ++) . (++ "|]")
 
--- | 
+-- |
 -- Parses a literal of zeros and ones.
--- 
+--
 -- >>> read "[qq|1110|]" :: BitArray Int8
 -- [qq|00001110|]
--- 
+--
 -- >>> unwrap (read "[qq|1110|]") :: Int
 -- 14
-instance (Bits a, Num a) => Read (BitArray a) where
+instance (FiniteBits a) => Read (BitArray a) where
   readsPrec = const $ ReadP.readP_to_S $ parser
     where
-      parser = 
+      parser =
         BitArray <$> ReadP.string "[qq|" *> Parser.bits <* ReadP.string "|]"
 
-instance (Bits a, Num a) => IsString (BitArray a) where
-  fromString = 
+instance (FiniteBits a) => IsString (BitArray a) where
+  fromString =
     fromMaybe (error "Unparsable bit array string") . parseString
 
 -- * Constructors and converters
 -------------------------
 
 -- |
--- A binary number quasi-quoter. 
+-- A binary number quasi-quoter.
 -- Produces a numeric literal at compile time.
 -- Can be used to construct both bit arrays and integral numbers.
--- 
+--
 -- >>> [qq|011|] :: Int
 -- 3
--- 
+--
 -- >>> [qq|011|] :: BitArray Int8
 -- [qq|00000011|]
 qq = NumericQQ.bin
@@ -90,78 +86,78 @@ unwrap (BitArray a) = a
 
 -- |
 -- Convert into a binary notation string.
--- 
+--
 -- >>> toString (BitArray (5 :: Int8))
 -- "00000101"
-toString :: (Bits a) => BitArray a -> String
+toString :: (FiniteBits a) => BitArray a -> String
 toString = fmap (\case True -> '1'; False -> '0') . reverse . toBoolList
 
 -- |
 -- Parse a binary notation string.
--- 
+--
 -- >>> parseString "123" :: Maybe (BitArray Int8)
 -- Nothing
--- 
+--
 -- >>> parseString "101" :: Maybe (BitArray Int8)
 -- Just [qq|00000101|]
-parseString :: (Bits a, Num a) => String -> Maybe (BitArray a)
+parseString :: (FiniteBits a) => String -> Maybe (BitArray a)
 parseString = fmap fst . listToMaybe . ReadP.readP_to_S Parser.bits
 
 -- ** Lists
 -------------------------
 
--- | 
+-- |
 -- Convert into a list of set bits.
--- 
+--
 -- The list is ordered from least significant to most significant bit.
 {-# INLINABLE toList #-}
-toList :: (Bits a, Num a) => BitArray a -> [a]
-toList (BitArray w) = 
-  processIndexes [0 .. (pred . bitSize) w]
+toList :: (FiniteBits a) => BitArray a -> [a]
+toList (BitArray w) =
+  processIndexes [0 .. (pred . finiteBitSize) w]
   where
-    processIndexes = filter (\w' -> w .&. w' /= 0) . fmap bit
+    processIndexes = filter (\w' -> w .&. w' /= zeroBits) . fmap bit
 
 -- | Construct from a list of set bits.
 {-# INLINABLE fromList #-}
-fromList :: (Bits a, Num a) => [a] -> BitArray a
-fromList = BitArray . inline Foldable.foldr (.|.) 0
+fromList :: (FiniteBits a) => [a] -> BitArray a
+fromList = BitArray . inline Foldable.foldr (.|.) zeroBits
 
--- | 
+-- |
 -- Convert into a list of boolean values,
 -- which represent the \"set\" flags of each bit.
--- 
+--
 -- The list is ordered from least significant to most significant bit.
 {-# INLINABLE toBoolList #-}
-toBoolList :: (Bits a) => BitArray a -> [Bool]
-toBoolList (BitArray w) = testBit w <$> [0 .. (pred . bitSize) w]
+toBoolList :: (FiniteBits a) => BitArray a -> [Bool]
+toBoolList (BitArray w) = testBit w <$> [0 .. (pred . finiteBitSize) w]
 
--- | 
+-- |
 -- Construct from a list of boolean flags for the "set" status of each bit.
--- 
+--
 -- The list must be ordered from least significant to most significant bit.
 {-# INLINABLE fromBoolList #-}
-fromBoolList :: (Bits a, Num a) => [Bool] -> BitArray a
-fromBoolList = inline fromList . fmap (bit . fst) . filter snd . zip [0..]
+fromBoolList :: (FiniteBits a) => [Bool] -> BitArray a
+fromBoolList = inline fromList . fmap (bit . fst) . filter snd . zip [zeroBits..]
 
 -- * Utils
 -------------------------
 
 -- | Map over the set bits.
 {-# INLINABLE map #-}
-map :: (Bits a, Num a, Bits b, Num b) => (a -> b) -> BitArray a -> BitArray b
+map :: (FiniteBits a, FiniteBits b) => (a -> b) -> BitArray a -> BitArray b
 map f = inline fromList . fmap f . inline toList
 
 -- | Perform a right-associative fold over the set bits.
 {-# INLINABLE foldr #-}
-foldr :: (Bits a, Num a) => (a -> b -> b) -> b -> BitArray a -> b
+foldr :: (FiniteBits a) => (a -> b -> b) -> b -> BitArray a -> b
 foldr step init = inline Foldable.foldr step init . inline toList
 
 -- | Traverse thru set bits.
 {-# INLINABLE mapM_ #-}
-mapM_ :: (Bits a, Num a, Monad m) => (a -> m b) -> BitArray a -> m ()
+mapM_ :: (FiniteBits a, Monad m) => (a -> m b) -> BitArray a -> m ()
 mapM_ f = inline Foldable.mapM_ f . inline toList
 
 -- | Traverse thru set bits.
 {-# INLINABLE traverse_ #-}
-traverse_ :: (Bits a, Num a, Applicative f) => (a -> f b) -> BitArray a -> f ()
+traverse_ :: (FiniteBits a, Applicative f) => (a -> f b) -> BitArray a -> f ()
 traverse_ f = inline Foldable.traverse_ f . inline toList

--- a/library/BitArray/Parser.hs
+++ b/library/BitArray/Parser.hs
@@ -18,6 +18,6 @@ bitIndexes = do
       '1' -> return (return index)
       _   -> return empty
 
-bits :: (Bits a, Num a) => ReadP a
-bits = foldr (.|.) 0 . map bit <$> bitIndexes
+bits :: (FiniteBits a) => ReadP a
+bits = foldr (.|.) zeroBits . map bit <$> bitIndexes
 


### PR DESCRIPTION
Use `FiniteBits` typeclass instead of `Bits` so that `finiteBitSize` can be leveraged.  `finiteBitSize` is a drop-in replacement for the partial function, `bitSize`.  This will sidestep exceptions altogether as it would be a build error if the user tried to do something with a `BitArray Integer`.  Was also able to avoid  `Num` constraints via use of `zeroBits`.

In addition to the above, this branch also has:
- Fixed issue with non-existent Hierarchy.png image trying to be copied in the build script.
- Relaxed `doctest` and `filepath` dependency constraints.
- Bumped min version of `numeric-qq` to 0.1.3.
- Set range of acceptable versions of `base`.
